### PR TITLE
doc: [#22] deprecate polyfill.io in live-demo page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -7,9 +7,9 @@
 <meta name="description" content="">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
-<script defer src="bundle.js?3f04a30487643035021e"></script></head>
+<script defer src="bundle.js?48b85b74af24a30cb146"></script></head>
 <body>
 <div id="container"></div>
-<script src="https://polyfill.io/v3/polyfill.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?version=4.8.0" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/examples/index.html
+++ b/examples/index.html
@@ -10,6 +10,6 @@
 </head>
 <body>
 <div id="container"></div>
-<script src="https://polyfill.io/v3/polyfill.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?version=4.8.0" crossorigin="anonymous"></script>
 </body>
 </html>


### PR DESCRIPTION
Deprecate https://polyfill.io/ by replacing it with https://cdnjs.cloudflare.com/polyfill/