### PR TITLE
fix: [#32] lint-staged failed with TypeScript TS17004 issue

### DIFF
--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,0 +1,15 @@
+module.exports = {
+  '{src,examples}/**/*.{ts,tsx}': [
+    () => 'tsc --noEmit',
+    'prettier --write',
+    'eslint --cache --fix --max-warnings 0',
+  ],
+  '{src,examples}/**/*.{js,jsx}': [
+    'prettier --write',
+    'eslint --cache --fix --max-warnings 0',
+  ],
+  '{src,examples}/**/*.scss': [
+    'prettier --write',
+    'stylelint --fix --custom-syntax postcss-scss',
+  ],
+};

--- a/package.json
+++ b/package.json
@@ -15,21 +15,8 @@
     "lint": "yarn run lint:style && yarn run lint:eslint && yarn run lint:typescript",
     "lint:eslint": "eslint --max-warnings 0 --ext .jsx,.js,.tsx,.ts src examples",
     "lint:style": "stylelint --custom-syntax postcss-scss '**/*.scss' --fix",
-    "lint:typescript": "tsc --noEmit true",
+    "lint:typescript": "tsc --noEmit",
     "start": "cd examples; webpack && webpack serve"
-  },
-  "lint-staged": {
-    "{src,examples}/**/*.{ts,tsx}": [
-      "tsc --noEmit true"
-    ],
-    "{src,examples}/**/*.{js,jsx,ts,tsx}": [
-      "prettier --write",
-      "eslint --fix --max-warnings 0"
-    ],
-    "{src,examples}/**/*.scss": [
-      "prettier --write",
-      "stylelint --fix --custom-syntax postcss-scss"
-    ]
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Issue**

lint-staged failed during TypeScript checking. The error message below shows up.

```
examples/index.tsx(82,13): error TS17004: Cannot use JSX unless the '--jsx' flag is provided.
```

**Root cause**

TL;DR When lint-staged is invoked by Husky, it fails to locate the project folder and configuration file (e.g., `tsconfig.json`).


1. `By default lint-staged automatically adds the list of matched staged files to your command` according to [the README of lint-staged](https://github.com/lint-staged/lint-staged?tab=readme-ov-file#using-js-configuration-files).
For example,
```js
  "{src,examples}/**/*.{ts,tsx}": [
    "tsc --noEmit"
  ],
```
The above config will result in lint-staged first running `tsc --noEmit file-1.ts file-2.ts` when we have staged files file-1.ts, file-2.ts and README.md.

2. Certain input files can cause TypeScript to ignore tsconfig.json. For more details, refer to this issue in the TypeScript repository: https://github.com/microsoft/TypeScript/issues/27379

**Provided Solution**
- Split the lint-staged settings from the package.json to lint-staged.config.js, and apply the function syntax on the tsc command, so that the files will not be applied to it.
```js
  '{src,examples}/**/*.{ts,tsx}': [
    () => 'tsc --noEmit',
    'prettier --write',
    'eslint --cache --fix --max-warnings 0',
  ],
```

**Reference**

1. [husky + lint staged でコミット時に型チェックをする](https://zenn.dev/d3g/scraps/a41dca9a3ecda8)
2. [Cannot use JSX unless the '--jsx' flag is provided using lint-staged](https://stackoverflow.com/a/79124840)
4. https://github.com/lint-staged/lint-staged/issues/825#issuecomment-2393146853