### PR TITLE
build: update husky config based on Husky v9.1.2 release note

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 yarn lint-staged


### PR DESCRIPTION
Update husky config based on husky@9.1.2

**Reason:** 
In the release note of Husky [v9.1.2](https://github.com/typicode/husky/releases/tag/v9.1.2), it is stated

> Show a message instead of automatically removing deprecated code.
> 
> This only concerns projects that still have the following code in their hooks:
> 
> ```js
> - #!/usr/bin/env sh # <- This is deprecated, remove it
> - . "$(dirname -- "$0")/_/husky.sh"  # <- This is deprecated, remove it
> ```
> # Rest of your hook code
> Hooks with these lines will fail in v10.0.0