### PR TITLE
fix: sassOptions name issue after migrate package node-sass to sass

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -101,7 +101,7 @@ module.exports = {
             loader: 'sass-loader', // compiles SASS to CSS
             options: {
               sassOptions: {
-                outputStyle: 'expanded',
+                style: 'expanded',
               },
               sourceMap: false,
             },


### PR DESCRIPTION
sassOptions name should be change to `style` after migrate package `node-sass` to `sass`